### PR TITLE
1.1.4

### DIFF
--- a/MQTTSyncClientConfigurator/module.json
+++ b/MQTTSyncClientConfigurator/module.json
@@ -13,5 +13,6 @@
     "implemented": [
         "{7F7632D9-FA40-4F38-8DEA-C83CD4325A32}"
     ],
-    "prefix": "MQTTSYNC"
+    "prefix": "MQTTSYNC",
+    "url": "https://github.com/Schnittcher/IPS-MQTTSync/blob/master/MQTTSyncClientConfigurator/README.md"
 }

--- a/MQTTSyncClientConfigurator/module.php
+++ b/MQTTSyncClientConfigurator/module.php
@@ -24,7 +24,6 @@ class MQTTSyncClientConfigurator extends IPSModule
         foreach ($Devices as $Device) {
             $instanceID = $this->getMQTTSyncClientDeviceInstance($Device->MQTTTopic);
 
-            $tmpDevice = [];
             $tmpDevice = [
                 'ObjectID'      => $Device->ObjectID,
                 'ObjectName'    => $Device->ObjectName,
@@ -53,7 +52,6 @@ class MQTTSyncClientConfigurator extends IPSModule
     {
         //Never delete this line!
         parent::ApplyChanges();
-        $this->ConnectParent('{EE0D345A-CF31-428A-A613-33CE98E752DD}');
 
         $MQTTTopic = $this->ReadPropertyString('GroupTopic');
         $this->SetReceiveDataFilter('.*' . $MQTTTopic . '.*');

--- a/MQTTSyncClientConfigurator/module.php
+++ b/MQTTSyncClientConfigurator/module.php
@@ -1,10 +1,10 @@
-<?php
+<?php /** @noinspection AutoloadingIssuesInspection */
 
 declare(strict_types=1);
 
 class MQTTSyncClientConfigurator extends IPSModule
 {
-    public function Create()
+    public function Create(): void
     {
         //Never delete this line!
         parent::Create();
@@ -13,7 +13,7 @@ class MQTTSyncClientConfigurator extends IPSModule
         $this->RegisterAttributeString('Devices', '[]');
     }
 
-    public function GetConfigurationForm()
+    public function GetConfigurationForm(): string
     {
         $Form = json_decode(file_get_contents(__DIR__ . '/form.json'), true);
         $Devices = $this->ReadAttributeString('Devices');
@@ -48,7 +48,7 @@ class MQTTSyncClientConfigurator extends IPSModule
         return json_encode($Form);
     }
 
-    public function ApplyChanges()
+    public function ApplyChanges(): void
     {
         //Never delete this line!
         parent::ApplyChanges();
@@ -57,7 +57,7 @@ class MQTTSyncClientConfigurator extends IPSModule
         $this->SetReceiveDataFilter('.*' . $MQTTTopic . '.*');
     }
 
-    public function ReceiveData($JSONString)
+    public function ReceiveData($JSONString): string
     {
         $this->SendDebug('ReceiveData JSON', $JSONString, 0);
         $Data = json_decode($JSONString);
@@ -96,6 +96,7 @@ class MQTTSyncClientConfigurator extends IPSModule
                 }
             }
         }
+        return '';
     }
 
     private function getMQTTSyncClientDeviceInstance($Topic)

--- a/MQTTSyncClientDevice/form.json
+++ b/MQTTSyncClientDevice/form.json
@@ -12,6 +12,7 @@
         }
     ],
     "actions": [
+        {"type": "TestCenter"},
         {
             "type": "Label",
             "caption": "Spenden / Schenkung"

--- a/MQTTSyncClientDevice/module.json
+++ b/MQTTSyncClientDevice/module.json
@@ -13,5 +13,6 @@
     "implemented": [
         "{7F7632D9-FA40-4F38-8DEA-C83CD4325A32}"
     ],
-    "prefix": "MQTTSYNC"
+    "prefix": "MQTTSYNC",
+    "url": "https://github.com/Schnittcher/IPS-MQTTSync/blob/master/MQTTSyncClientDevice/README.md"
 }

--- a/MQTTSyncClientDevice/module.php
+++ b/MQTTSyncClientDevice/module.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection AutoloadingIssuesInspection */
 
 declare(strict_types=1);
 
@@ -7,7 +7,7 @@ class MQTTSyncClientDevice extends IPSModule
     private const GUID_MQTT_SEND = '{043EA491-0325-4ADD-8FC2-A30C8EEB4D3F}';
     private const MQTT_PACKET_PUBLISH = 3;
 
-    public function Create()
+    public function Create(): void
     {
         //Never delete this line!
         parent::Create();
@@ -16,7 +16,7 @@ class MQTTSyncClientDevice extends IPSModule
         $this->RegisterPropertyString('GroupTopic', '');
     }
 
-    public function ApplyChanges()
+    public function ApplyChanges(): void
     {
         //Never delete this line!
         parent::ApplyChanges();
@@ -34,7 +34,7 @@ class MQTTSyncClientDevice extends IPSModule
         }
     }
 
-    public function ReceiveData($JSONString)
+    public function ReceiveData($JSONString): string
     {
         $this->SendDebug('ReceiveData JSON', $JSONString, 0);
         $Data = json_decode($JSONString);
@@ -43,7 +43,7 @@ class MQTTSyncClientDevice extends IPSModule
         $this->ensureUtf8Payload($Data);
 
         if (!property_exists($Data, 'Topic')) {
-            return;
+            return '';
         }
 
         $Variablen = json_decode($Data->Payload, true, 512, JSON_THROW_ON_ERROR);
@@ -51,6 +51,7 @@ class MQTTSyncClientDevice extends IPSModule
         foreach ($Variablen as $Variable) {
             $this->processReceivedVariable($Variable);
         }
+        return '';
     }
 
     private function processReceivedVariable(array $Variable): void
@@ -100,7 +101,7 @@ class MQTTSyncClientDevice extends IPSModule
         }
     }
 
-    public function RequestAction($Ident, $Value)
+    public function RequestAction($Ident, $Value): void
     {
         $Payload = [];
         $Payload['ObjectIdent'] = $Ident;

--- a/MQTTSyncClientDevice/module.php
+++ b/MQTTSyncClientDevice/module.php
@@ -41,46 +41,49 @@ class MQTTSyncClientDevice extends IPSModule
             $Data->Payload = utf8_decode($Data->Payload);
         }
 
-        if (property_exists($Data, 'Topic')) {
-            $Variablen = json_decode($Data->Payload);
-            foreach ($Variablen as $Variable) {
-                if ($Variable->ObjectIdent == '') {
-                    $ObjectIdent = $Variable->ID;
-                } else {
-                    $ObjectIdent = $Variable->ObjectIdent;
-                }
+        if (!property_exists($Data, 'Topic')) {
+            return;
+        }
 
-                if ($Variable->VariableCustomProfile != '') {
-                    $VariableProfile = $Variable->VariableCustomProfile;
-                } else {
-                    $VariableProfile = $Variable->VariableProfile;
-                }
-                $ID = $this->GetIDForIdent($ObjectIdent);
-                if (!$ID) {
-                    switch ($Variable->VariableTyp) {
-                        case 0:
-                            $this->RegisterVariableBoolean($ObjectIdent, $Variable->Name, $VariableProfile);
-                            break;
-                        case 1:
-                            $this->RegisterVariableInteger($ObjectIdent, $Variable->Name, $VariableProfile);
-                            break;
-                        case 2:
-                            $this->RegisterVariableFloat($ObjectIdent, $Variable->Name, $VariableProfile);
-                            break;
-                        case 3:
-                            $this->RegisterVariableString($ObjectIdent, $Variable->Name, $VariableProfile);
-                            break;
-                        default:
-                            IPS_LogMessage('MQTTSync Client', 'invalid variablen profile');
-                            break;
-                    }
-                    if ($Variable->VariableAction != 0 || $Variable->VariableCustomAction != 0) {
-                        $this->EnableAction($ObjectIdent);
-                    }
-                }
-                $this->SendDebug('Value for ' . $ObjectIdent . ':', $Variable->Value, 0);
-                $this->SetValue($ObjectIdent, $Variable->Value);
+        $Variablen = json_decode($Data->Payload);
+
+        foreach ($Variablen as $Variable) {
+            if ($Variable->ObjectIdent == '') {
+                $ObjectIdent = $Variable->ID;
+            } else {
+                $ObjectIdent = $Variable->ObjectIdent;
             }
+
+            if ($Variable->VariableCustomProfile != '') {
+                $VariableProfile = $Variable->VariableCustomProfile;
+            } else {
+                $VariableProfile = $Variable->VariableProfile;
+            }
+            $ID = $this->GetIDForIdent($ObjectIdent);
+            if (!$ID) {
+                switch ($Variable->VariableTyp) {
+                    case VARIABLETYPE_BOOLEAN:
+                        $this->RegisterVariableBoolean($ObjectIdent, $Variable->Name, $VariableProfile);
+                        break;
+                    case VARIABLETYPE_INTEGER:
+                        $this->RegisterVariableInteger($ObjectIdent, $Variable->Name, $VariableProfile);
+                        break;
+                    case VARIABLETYPE_FLOAT:
+                        $this->RegisterVariableFloat($ObjectIdent, $Variable->Name, $VariableProfile);
+                        break;
+                    case VARIABLETYPE_STRING:
+                        $this->RegisterVariableString($ObjectIdent, $Variable->Name, $VariableProfile);
+                        break;
+                    default:
+                        IPS_LogMessage('MQTTSync Client', 'invalid variablen profile');
+                        break;
+                }
+                if ($Variable->VariableAction != 0 || $Variable->VariableCustomAction != 0) {
+                    $this->EnableAction($ObjectIdent);
+                }
+            }
+            $this->SendDebug('Value for ' . $ObjectIdent . ':', $Variable->Value, 0);
+            $this->SetValue($ObjectIdent, $Variable->Value);
         }
     }
 

--- a/MQTTSyncServer/module.json
+++ b/MQTTSyncServer/module.json
@@ -13,5 +13,6 @@
     "implemented": [
         "{7F7632D9-FA40-4F38-8DEA-C83CD4325A32}"
     ],
-    "prefix": "MQTTSYNC"
+    "prefix": "MQTTSYNC",
+    "url": "https://github.com/Schnittcher/IPS-MQTTSync/blob/master/MQTTSyncServer/README.md"
 }

--- a/MQTTSyncServer/module.php
+++ b/MQTTSyncServer/module.php
@@ -328,7 +328,7 @@ class MQTTSyncServer extends IPSModule
             'Value'                 => GetValue($objectId),
             'VariableTyp'           => $variable['VariableType'],
             'VariableAction'        => $variable['VariableAction'],
-            'VariableCustomAction'  => $variable['VariableAction'], // War im Original so, ggf. prüfen ob CustomAction gemeint war?
+            'VariableCustomAction'  => $variable['VariableCustomAction'],
             'VariableProfile'       => $variable['VariableProfile'],
             'VariableCustomProfile' => $variable['VariableCustomProfile'],
             'VariablePresentation'  => $variable['VariablePresentation']??null,

--- a/MQTTSyncServer/module.php
+++ b/MQTTSyncServer/module.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection AutoloadingIssuesInspection */
 
 declare(strict_types=1);
 
@@ -8,7 +8,7 @@ class MQTTSyncServer extends IPSModule
     private const GUID_MQTT_SEND = '{043EA491-0325-4ADD-8FC2-A30C8EEB4D3F}';
     private const MQTT_PACKET_PUBLISH = 3;
 
-    public function Create()
+    public function Create(): void
     {
         //Never delete this line!
         parent::Create();
@@ -90,7 +90,7 @@ class MQTTSyncServer extends IPSModule
         }
     }
 
-    public function ReceiveData($JSONString)
+    public function ReceiveData($JSONString): string
     {
         $this->SendDebug('ReceiveData JSON', $JSONString, 0);
         $Data = json_decode($JSONString);
@@ -122,7 +122,7 @@ class MQTTSyncServer extends IPSModule
                 } else {
                     SetValue($VariablenID, $Payload->Value);
                 }
-                return;
+                return '';
             }
 
             if ($Topic == 'get') {
@@ -135,7 +135,7 @@ class MQTTSyncServer extends IPSModule
                         $this->SendDebug(__FUNCTION__, 'Invalid get Payload: ' . $Payload->config, 0);
                         break;
                 }
-                return;
+                return '';
             }
 
             $this->SendDebug(__FUNCTION__ . ' Topic', $Topic, 0);
@@ -155,6 +155,7 @@ class MQTTSyncServer extends IPSModule
                 }
             }
         }
+        return '';
     }
 
     public function sendData(string $Payload)
@@ -333,7 +334,9 @@ class MQTTSyncServer extends IPSModule
             'VariableCustomProfile' => $variable['VariableCustomProfile'],
             'VariablePresentation'  => $variable['VariablePresentation']??null,
             'VariableCustomPresentation' => $variable['VariableCustomPresentation']??null
-        ]);
+        ], function ($value) {
+            return !is_null($value);
+        });
     }
 
     private function SendMQTTData(string $topic, string $payload): void

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "compatibility": {
         "version": "5.5"
     },
-    "version": "1.1.7",
+    "version": "1.1.8",
     "build": 0,
     "date": 0
 }

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "compatibility": {
         "version": "5.5"
     },
-    "version": "1.1.4",
+    "version": "1.1.5",
     "build": 0,
     "date": 0
 }

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "compatibility": {
         "version": "5.5"
     },
-    "version": "1.1.6",
+    "version": "1.1.7",
     "build": 0,
     "date": 0
 }

--- a/library.json
+++ b/library.json
@@ -3,7 +3,10 @@
     "author": "Kai Schnittcher",
     "name": "MQTTSync",
     "url": "https://github.com/Schnittcher/IPS-MQTTSync",
-    "version": "1.1.3",
+    "compatibility": {
+        "version": "5.5"
+    },
+    "version": "1.1.4",
     "build": 0,
     "date": 0
 }

--- a/library.json
+++ b/library.json
@@ -6,7 +6,7 @@
     "compatibility": {
         "version": "5.5"
     },
-    "version": "1.1.5",
+    "version": "1.1.6",
     "build": 0,
     "date": 0
 }


### PR DESCRIPTION
MQTTSyncServer
- Referenzierung der Instanzen korrigiert
- sendData korrigiert
- neu: es werden jetzt auch Darstellungen mit übermittelt

MQTTSyncClientConfigurator
- ConnectParent korrigiert
- neu: Übernahme von Darstellungen
- neu: TestCenter

Allgemein:
- Verweis zur Doku aufgenommen
- Mindestvoraussetzung auf Symcon 5.5 gesetzt